### PR TITLE
Fix AssetException for vast-immortal-suns.ogg

### DIFF
--- a/biomes/surface/fugasgiant.biome.patch
+++ b/biomes/surface/fugasgiant.biome.patch
@@ -29,7 +29,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/fungus.biome.patch
+++ b/biomes/surface/fungus.biome.patch
@@ -29,7 +29,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/grasslands.biome.patch
+++ b/biomes/surface/grasslands.biome.patch
@@ -23,7 +23,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/jungle.biome.patch
+++ b/biomes/surface/jungle.biome.patch
@@ -25,7 +25,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/magma.biome.patch
+++ b/biomes/surface/magma.biome.patch
@@ -27,7 +27,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/magmadark.biome.patch
+++ b/biomes/surface/magmadark.biome.patch
@@ -27,7 +27,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/savannah.biome.patch
+++ b/biomes/surface/savannah.biome.patch
@@ -25,7 +25,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},

--- a/biomes/surface/toxic.biome.patch
+++ b/biomes/surface/toxic.biome.patch
@@ -26,7 +26,7 @@
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/planetarium.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/procyon.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/stellarformation.ogg"},
-{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vastimmortalsuns.ogg"},
+{"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/vast-immortal-suns.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/atlas.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/blue-straggler.ogg"},
 {"op":"add", "path":"/musicTrack/day/tracks/-", "value":"/music/cygnus-x1.ogg"},


### PR DESCRIPTION
I created a quick fix while testing mods in the game and saw an error in the log because it couldn't find "vastimmortalsuns.ogg". The actual music file apparently has dashes between each part of the name, so this should fix the error (though it's only minor, as it doesn't crash the game).

(sorry if I shouldn't make a pull request; I'm not sure what the correct etiquette here is...)